### PR TITLE
Fix sidebar toggle detachment in Firefox by anchoring it to the sidebar

### DIFF
--- a/src/pbir_utils/templates/client.html.j2
+++ b/src/pbir_utils/templates/client.html.j2
@@ -55,7 +55,7 @@
         }
 
         .sidebar.collapsed {
-            width: 0;
+            width: 0 !important;
             min-width: 0;
             border-right: none;
         }
@@ -84,7 +84,7 @@
         /* Sidebar Toggle Button */
         .sidebar-toggle {
             position: absolute;
-            left: var(--sidebar-width);
+            right: -16px;
             top: 50%;
             transform: translateY(-50%);
             width: 16px;
@@ -101,7 +101,7 @@
             padding: 0;
             color: var(--text-secondary);
             z-index: 90;
-            transition: left 0.25s ease, background 0.15s, color 0.15s;
+            transition: background 0.15s, color 0.15s;
             box-shadow: 2px 0 8px rgba(0,0,0,0.05);
         }
 
@@ -110,14 +110,13 @@
             color: white;
         }
 
-        .sidebar.collapsed + .sidebar-toggle {
-            left: 0;
+        .sidebar.collapsed .sidebar-toggle {
             background: var(--accent-color);
             color: white;
             border-color: var(--accent-color);
         }
 
-        .sidebar.collapsed + .sidebar-toggle:hover {
+        .sidebar.collapsed .sidebar-toggle:hover {
             background: var(--accent-hover);
         }
 
@@ -127,7 +126,7 @@
             height: 10px;
         }
 
-        .sidebar.collapsed + .sidebar-toggle .chevron {
+        .sidebar.collapsed .sidebar-toggle .chevron {
             transform: rotate(180deg);
         }
         
@@ -818,12 +817,12 @@
             </div>
             
             <div class="sidebar-resizer" onmousedown="initSidebarResize(event)"></div>
+            <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Toggle Sidebar" aria-label="Toggle Sidebar" aria-expanded="true" aria-controls="sidebar">
+                <svg class="chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+            </button>
         </aside>
-        <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Toggle Sidebar" aria-label="Toggle Sidebar" aria-expanded="true" aria-controls="sidebar">
-            <svg class="chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <polyline points="15 18 9 12 15 6"></polyline>
-            </svg>
-        </button>
 
         <!-- Main Content -->
         <main class="main-content-wrapper">


### PR DESCRIPTION
## Description

Fixes a Firefox-only layout bug where the sidebar toggle button could appear detached from the sidebar edge. The toggle is now positioned relative to the sidebar so it stays aligned as the sidebar width changes.

Key changes:
- Anchor toggle to the sidebar edge using `right: -16px` instead of `left: var(--sidebar-width)` (`client.html.j2`).
- Remove the `left` transition so the control isn’t coupled to sidebar width (`client.html.j2`).
- Replace sibling collapsed selectors with descendant selectors (`client.html.j2`).
- Move the toggle markup inside `<aside id="sidebar">` so it positions relative to the sidebar (`client.html.j2`).

Non-changes:
- `toggleSidebar()` logic and ARIA updates remain unchanged (`client.js`).

Dependencies: none.

Issue: N/A (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Automated checks:
- [x] I have ran `pytest` and all tests passed
- [x] I have ran `pytest --cov=pbir_utils` to verify coverage
- [ ] I have built the documentation locally with `mkdocs build`

Manual verification:
- Please confirm UI behaviour in Firefox and Chrome (before/after screenshots attached).

Repro steps:
1. Launch the UI (e.g. `pbir-utils ui`).
2. In Firefox, open a report and toggle the sidebar open/closed.
3. Confirm the toggle stays attached to the sidebar edge and transitions correctly across different sidebar widths.
4. Repeat in Chrome to ensure no regression.

## Checklist:

- [x] My code follows the style guidelines of this project (ran `ruff format .` and `ruff check .`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not required for this change)
- [ ] I have made corresponding changes to the documentation (not required for this change)
- [ ] My changes generate no new warnings (covered by ruff check)
- [ ] I have added tests that prove my fix is effective or that my feature works (UI/CSS change)
- [x] New and existing unit tests pass locally with my changes

<img width="831" height="274" alt="Before" src="https://github.com/user-attachments/assets/949a04e1-02fc-4fa5-bfdd-4017c5298b1a" />
<img width="853" height="341" alt="After" src="https://github.com/user-attachments/assets/ad308ff4-673f-4e7b-94a4-94c5d718d4ec" />